### PR TITLE
Remove gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "DuckLib"]
-	path = DuckLib
-	url = https://github.com/oitzujoey/DuckLib


### PR DESCRIPTION
Hi,

duck-lisp janitor here 🦆  ;()

Should this file be removed now that DuckLib is part of duck-lisp?